### PR TITLE
Multipart request utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ if( UNITTEST_LIBRARY )
         ../tests/server_tests.cpp
         ../tests/type_tests.cpp
         ../tests/url_encode_tests.cpp
+        ../tests/multipart_tests.cpp
         ../tests/async_utils.cpp
     )
     TARGET_LINK_LIBRARIES(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,3 +66,7 @@ ADD_EXECUTABLE(
     multiple_clients
     ../examples/multiple_clients.cpp
 )
+ADD_EXECUTABLE(
+    multipart_form_handling
+    ../examples/multipart_form_handling.cpp
+)

--- a/doc/Utilities.rst
+++ b/doc/Utilities.rst
@@ -4,12 +4,12 @@ Separate Utilities
 
 These are some useful utilities included with SHOW, but in their own header files so they're optional.
 
+.. cpp:namespace-push:: show
+
 Base-64 Encoding
 ================
 
 These are utilities for handling `base64 <https://en.wikipedia.org/wiki/Base64>`_-encoded strings, very commonly used for transporting binary data in web applications.  They are included in *show/base64.hpp*.
-
-.. cpp:namespace-push:: show
 
 .. cpp:function:: string base64_encode( const std::string& o, const char* chars = base64_chars_standard )
     
@@ -48,3 +48,80 @@ These are utilities for handling `base64 <https://en.wikipedia.org/wiki/Base64>`
     
     * ``+`` → ``-``
     * ``/`` → ``_``
+
+Multipart Content Support
+=========================
+
+`Multipart content <https://en.wikipedia.org/wiki/MIME#Multipart_messages>`_ is used to send a number of data segments each with their own separate headers.  As such, text and binary data can be mixed in the same message.
+
+SHOW provides the following utilities for parsing multipart requests in *show/multipart.hpp*.  Typically, the ``Content-Type`` header for these types of requests will look something like::
+    
+    Content-Type: multipart/form-data; boundary=AaB03x
+
+The boundary string must be extracted from the header to pass to :cpp:class:`multipart`'s constructor.  A simple example with no error handling::
+    
+    const auto& header_value = request.headers()[ "Content-Type" ][ 0 ];
+    auto content_supertype = header_value.substr( 0, header_value.find( "/" ) )
+    if( content_supertype == "multipart" )
+    {
+        show::multipart parser{
+            request,
+            header_value.substr( header_value.find( "boundary=" ) + 9 )
+        };
+        
+        // Iterate over multipart data ...
+    }
+    else
+        // Process data as single message ...
+
+.. cpp:class:: multipart
+    
+    class description
+    
+    .. cpp:function:: template< class String > multipart( std::streambuf& buffer, String&& boundary )
+        
+        Constructs a new multipart content parser.
+        
+        The supplied buffer will typically be a :cpp:class:`request` object, but because multipart content can contain other multipart content recursively it can also be a :cpp:class:`show::multipart::segment`.  The ``boundary`` variable is a `perfectly-forwarded <http://en.cppreference.com/w/cpp/utility/forward>`_ boundary string for the multipart data.
+        
+        Throws :cpp:class:`std::invalid_argument` if the boundary is an empty string.
+        
+        .. seealso::
+            
+            * :cpp:class:`std::invalid_argument` on `cppreference.com <en.cppreference.com/w/cpp/error/invalid_argument>`_
+    
+    .. cpp:function:: multipart::iterator begin()
+        
+        Returns an iterator pointing to the first segment in the multipart content.  Calling this more than once on the same :cpp:class:`multipart` throws a :cpp:class:`std::logic_error`.
+        
+        .. seealso::
+            
+            * :cpp:class:`std::logic_error` on `cppreference.com <en.cppreference.com/w/cpp/error/logic_error>`_
+    
+    .. cpp:function:: multipart::iterator end()
+        
+        Returns an iterator representing the end of the multipart content.
+    
+    .. cpp:function:: const std::string& boundary()
+        
+        The boundary string the :cpp:class:`multipart` is using to split the content
+    
+    .. cpp:function:: const std::streambuf& buffer()
+        
+        The buffer the :cpp:class:`multipart` is reading from
+
+.. cpp:class:: multipart::iterator
+    
+    Iterator type for iterating over multipart data segments.  Implements most of `input iterator functionality <http://en.cppreference.com/w/cpp/concept/InputIterator>`_, except that its ``value_type`` (:cpp:class:`multipart::segment`) cannot be copied.
+
+.. cpp:class:: multipart::segment : public std::streambuf
+    
+    Represents a segment of data in the multipart content being iterated over.  Cannot be copied.
+    
+    .. cpp:function:: const headers_type& headers()
+        
+        The headers for this individual segment of data; does not include the request's headers.
+
+.. cpp:class:: multipart_parse_error : public request_parse_error
+    
+    Thrown when creating a :cpp:class:`multipart`, iterating over parts, or reading from a :cpp:class:`multipart::segment` whenever the content violates the multipart format.

--- a/examples/README.md
+++ b/examples/README.md
@@ -101,3 +101,7 @@ then navigate to `http://0.0.0.0:9090/` in your browser.
 # `multiple_clients`
 
 A multi-threaded server that handles one connection per thread, as a real application should.  This server doesn't do much except return *501 Not Implemented* for every request.
+
+#`multipart_form_handling`
+
+A very basic demonstration of the multipart content parsing utilities in `show/multipart.hpp`.  To try this example, run `multipart_form_handling` and navigate to `http://0.0.0.0:9090/form` in your browser.  You'll be presented with a very basic HTML form (which you can change by editing the example).  Upon submission, some information about the submitted form data will be displayed.

--- a/examples/multipart_form_handling.cpp
+++ b/examples/multipart_form_handling.cpp
@@ -1,0 +1,229 @@
+#include <show.hpp>
+#include <show/multipart.hpp>
+
+#include <iostream> // std::cout
+#include <iterator> // std::istreambuf_iterator
+#include <string>   // std::string, std::to_string()
+
+
+// Set a Server header to display the SHOW version
+const show::headers_type::value_type server_header{
+    "Server",
+    {
+        show::version::name
+        + " v"
+        + show::version::string
+    }
+};
+
+const std::string form{
+    R"###(<!doctype html>
+<html>
+    <head>
+        <meta charset=utf-8>
+        <title>Form Analyzer</title>
+    </head>
+    <body>
+        <form action="/analyze" method="post" enctype="multipart/form-data">
+            <div>
+                <label for="file">File:</label>
+                <input type="file" id="file" name="a_file"></input>
+            </div>
+            <div>
+                <label for="comment">Comment:</label>
+                <textarea id="comment" name="a_comment"></textarea>
+            </div>
+            <div>
+                <button type="submit">Analyze</button>
+            </div>
+        </form>
+    </body>
+</html>
+)###"
+};
+
+
+void get_form( show::request& request )
+{
+    show::response response{
+        request.connection(),
+        show::http_protocol::HTTP_1_0,
+        { 200, "OK" },
+        {
+            server_header,
+            { "Content-Type"  , { "text/html"                   } },
+            { "Content-Length", { std::to_string( form.size() ) } }
+        }
+    };
+    
+    response.sputn( form.c_str(), form.size() );
+}
+
+void analyze_form( show::request& request )
+{
+    auto found_content_type_header = request.headers().find( "Content-Type" );
+    if(
+        found_content_type_header == request.headers().end()
+        || found_content_type_header -> second.size() != 1
+        || found_content_type_header -> second[ 0 ].substr(
+            0, found_content_type_header -> second[ 0 ].find( ";" )
+        ) != "multipart/form-data"
+    )
+    {
+        std::cout
+            << "POST to analysis endpoint with improper/missing content type"
+            << std::endl
+        ;
+        
+        show::response response{
+            request.connection(),
+            show::http_protocol::HTTP_1_0,
+            { 400, "Bad Request" },
+            { server_header }
+        };
+    }
+    else
+    {
+        std::string analysis{ "Form contains:\n" };
+        auto header_value   = found_content_type_header -> second[ 0 ];
+        auto boundary_begin = header_value.find( "boundary=" ) + 9;
+        auto boundary_end   = header_value.find( ";", boundary_begin );
+        show::multipart parser{
+            request,
+            header_value.substr(
+                boundary_begin,
+                boundary_end
+            )
+        };
+        
+        for( auto& segment : parser )
+        {
+            auto content = std::string{
+                std::istreambuf_iterator< char >( &segment ),
+                {}
+            };
+            analysis += (
+                " -  segment with size "
+                + std::to_string( content.size() )
+                + " bytes, headers:\n"
+            );
+            for( auto& header : segment.headers() )
+                for( auto& value : header.second )
+                    analysis += (
+                        "     -  "
+                        + header.first
+                        + ": "
+                        + value
+                        + "\n"
+                    );
+            analysis += (
+                "    first eight bytes (URL-encoded): \""
+                + show::url_encode( content.substr( 0, 8 ) )
+                + "\"\n"
+            );
+        }
+        
+        std::string result_html{
+            "<!doctype html><html><head><meta charset=utf-8>"
+            "<title>Result</title></head><body><pre>"
+            + analysis
+            + "</pre></body></html>"
+        };
+        
+        show::response response{
+            request.connection(),
+            show::http_protocol::HTTP_1_0,
+            { 200, "OK" },
+            {
+                server_header,
+                { "Content-Type"  , { "text/html"                          } },
+                { "Content-Length", { std::to_string( result_html.size() ) } }
+            }
+        };
+        
+        response.sputn( result_html.c_str(), result_html.size() );
+    }
+}
+
+
+int main( int argc, char* argv[] )
+{
+    std::string  host   { "::" };   // IPv6 'any IP' (0.0.0.0 in IPv4)
+    unsigned int port   { 9090 };   // Some random higher port
+    int          timeout{ 10   };   // Connection timeout in seconds
+    
+    show::server test_server{
+        host,
+        port,
+        timeout
+    };
+    
+    while( true )
+        try
+        {
+            show::connection connection{ test_server.serve() };
+            
+            try
+            {
+                show::request request{ connection };
+                
+                if(
+                    request.path().size() == 1
+                    && request.path()[ 0 ] == "form"
+                )
+                {
+                    if( request.method() == "GET" )
+                    {
+                        get_form( request );
+                        continue;
+                    }
+                }
+                else if(
+                    request.path().size() == 1
+                    && request.path()[ 0 ] == "analyze"
+                )
+                {
+                    if( request.method() == "POST" )
+                    {
+                        analyze_form( request );
+                        continue;
+                    }
+                }
+                else
+                {
+                    show::response response{
+                        request.connection(),
+                        show::http_protocol::HTTP_1_0,
+                        { 404, "Not Found" },
+                        { server_header }
+                    };
+                    continue;
+                }
+                
+                show::response response{
+                    request.connection(),
+                    show::http_protocol::HTTP_1_0,
+                    { 405, "Method Not Allowed" },
+                    { server_header }
+                };
+            }
+            catch( const show::connection_interrupted& ct )
+            {
+                std::cout
+                    << "client "
+                    << connection.client_address()
+                    << " disconnected or timed out, closing connection"
+                    << std::endl
+                ;
+            }
+        }
+        catch( const show::connection_timeout& ct )
+        {
+            std::cout
+                << "timed out waiting for connection, looping..."
+                << std::endl
+            ;
+        }
+    
+    return 0;
+}

--- a/src/show/multipart.hpp
+++ b/src/show/multipart.hpp
@@ -1,0 +1,1154 @@
+#pragma once
+#ifndef SHOW_MULTIPART_HPP
+#define SHOW_MULTIPART_HPP
+
+
+#include "../show.hpp"
+
+#include <streambuf>
+#include <utility>  // std::forward<>()
+#include <vector>
+
+
+// DEBUG:
+#include <iostream>
+namespace __show
+{
+    inline std::string escape_seq( const std::string& s )
+    {
+        std::stringstream escaped;
+        for( auto& c : s )
+            switch( c )
+            {
+            case '\n': escaped <<  "\\n"; break;
+            case '\r': escaped <<  "\\r"; break;
+            case '\t': escaped <<  "\\t"; break;
+            case  '"': escaped << "\\\""; break;
+            default:
+                if( c >= 0x20 && c <= 0x7E  )
+                    escaped << c;
+                else
+                    escaped
+                        << std::hex
+                        << "\\x"
+                        << std::uppercase
+                        << std::setfill( '0' )
+                        << std::setw( 2 )
+                        << ( unsigned int )( unsigned char )c
+                        << std::nouppercase
+                    ;
+                break;
+            }
+        return escaped.str();
+    }
+}
+
+
+namespace show
+{
+    // Classes /////////////////////////////////////////////////////////////////
+    
+    
+    class multipart
+    {
+    protected:
+        std::streambuf& _buffer;
+        // bool            _begun;
+        std::string     _boundary;
+        enum class state
+        {
+            READY,
+            BEGUN,
+            FINISHED
+        } _state;
+        
+    public:
+        class segment;
+        class iterator;
+        
+        friend class segment;
+        friend class iterator;
+        
+        class segment : public std::streambuf
+        {
+            friend class iterator;
+            
+        protected:
+            multipart*   _parent;
+            headers_type _headers;
+            std::string  _buffer;
+            bool         _finished;
+            
+            static const char ASCII_ACK { '\x06' };
+            
+            segment();
+            segment( multipart&  );
+            segment(   segment&& ) = default;
+            
+            segment& operator =( segment&& );
+            
+        public:
+            segment( const segment& ) = delete;
+            
+            const headers_type& headers();
+            
+            // std::streambuf get functions
+            virtual std::streamsize showmanyc();
+            virtual int_type        underflow();
+            // virtual std::streamsize xsgetn(
+            //     char_type* s,
+            //     std::streamsize count
+            // );
+            virtual int_type        pbackfail(
+                int_type c = std::char_traits< char >::eof()
+            );
+            
+        #if 0
+            // DEBUG:
+            int_type sgetc()
+            {
+                std::cout
+                    << "multipart::segment::sgetc(): pre, buffer is \""
+                    << __show::escape_seq( _buffer )
+                    << "\" (\""
+                    << __show::escape_seq( _buffer.substr( 0, egptr() - eback() ) )
+                    << "\"); "
+                    << static_cast< void* >( eback() )
+                    << " eback - "
+                    << gptr() - eback()
+                    << " - gptr - "
+                    << egptr() - gptr()
+                    << " - egptr"
+                    << std::endl
+                ;
+                
+                int_type retval;
+                
+                if( gptr() == egptr() )
+                    retval = underflow();
+                else
+                    retval = traits_type::to_int_type( *gptr() );
+                
+                std::cout
+                    << "multipart::segment::sgetc(): returning '"
+                    << __show::escape_seq( { traits_type::to_char_type( retval ) } )
+                    << "'"
+                    << ( traits_type::not_eof( retval ) != retval ? "(EOF)" : "" )
+                    << ", buffer is \""
+                    << __show::escape_seq( _buffer )
+                    << "\" (\""
+                    << __show::escape_seq( _buffer.substr( 0, egptr() - eback() ) )
+                    << "\"); "
+                    << static_cast< void* >( eback() )
+                    << " eback - "
+                    << gptr() - eback()
+                    << " - gptr - "
+                    << egptr() - gptr()
+                    << " - egptr"
+                    << std::endl
+                ;
+                
+                return retval;
+            }
+            int_type sbumpc()
+            {
+                std::cout
+                    << "multipart::segment::sbumpc(): pre, buffer is \""
+                    << __show::escape_seq( _buffer )
+                    << "\" (\""
+                    << __show::escape_seq( _buffer.substr( 0, egptr() - eback() ) )
+                    << "\"); "
+                    << static_cast< void* >( eback() )
+                    << " eback - "
+                    << gptr() - eback()
+                    << " - gptr - "
+                    << egptr() - gptr()
+                    << " - egptr"
+                    << std::endl
+                ;
+                
+                int_type retval;
+                
+                if( gptr() == egptr() )
+                    retval = uflow();
+                else
+                {
+                    retval = traits_type::to_int_type( *gptr() );
+                    setg(
+                        eback(),
+                        gptr () + 1,
+                        egptr()
+                    );
+                }
+                
+                std::cout
+                    << "multipart::segment::sbumpc(): returning '"
+                    << __show::escape_seq( { traits_type::to_char_type( retval ) } )
+                    << "'"
+                    << ( traits_type::not_eof( retval ) != retval ? "(EOF)" : "" )
+                    << ", buffer is \""
+                    << __show::escape_seq( _buffer )
+                    << "\" (\""
+                    << __show::escape_seq( _buffer.substr( 0, egptr() - eback() ) )
+                    << "\"); "
+                    << static_cast< void* >( eback() )
+                    << " eback - "
+                    << gptr() - eback()
+                    << " - gptr - "
+                    << egptr() - gptr()
+                    << " - egptr"
+                    << std::endl
+                ;
+                
+                return retval;
+            }
+        #endif
+        };
+        
+        class iterator
+        {
+            friend class multipart;
+            
+        public:
+            using value_type        = segment;
+            using pointer           = segment*;
+            using reference         = segment&;
+            using iterator_category = std::input_iterator_tag;
+            
+        protected:
+            multipart&      _parent;
+            bool            _is_end;
+            bool            _locked;
+            std::streamsize _segment_index;
+            segment         _current_segment;
+            
+            iterator( multipart&, bool end = false );
+            iterator( const iterator& );
+            
+        public:
+            iterator( iterator&& ) = default;
+            
+            reference operator  *(                 );
+            pointer   operator ->(                 );
+            iterator& operator ++(                 );
+            iterator  operator ++( int             );
+            bool      operator ==( const iterator& ) const;
+        };
+        
+        template< class String > multipart(
+            std::streambuf&,
+            String&& boundary
+        );
+        multipart( multipart&& ) = default;
+        
+        const std::streambuf&   buffer();
+        const std::string   & boundary();
+        
+        iterator begin();
+        iterator   end();
+    };
+    
+    class multipart_parse_error : public request_parse_error
+    {
+        using request_parse_error::request_parse_error;
+    };
+    
+    
+    // Implementations /////////////////////////////////////////////////////////
+    
+    
+    // Segment -----------------------------------------------------------------
+    
+    // Initializes an invalid `segment` for use with `multipart::iterator`'s
+    // copy constructor
+    inline multipart::segment::segment() :
+        _parent  { nullptr },
+        _finished{ true    }
+    {}
+    
+    inline multipart::segment::segment( multipart& p ) :
+        _parent  { &p                            },
+        // \r (usually), \n, and two dashes followed by boundary
+        _buffer  ( p.boundary().size() + 4, '\0' ),
+        _finished{ false                         }
+    {
+        // Non-cost std::string::data() only available in C++17
+        setg(
+            const_cast< char* >( _buffer.data() ),
+            const_cast< char* >( _buffer.data() ),
+            const_cast< char* >( _buffer.data() )
+        );
+        
+        // DEBUG:
+        std::cout
+            << "multipart::segment::segment(): _buffer.data() = "
+            << static_cast< const void* >( _buffer.data() )
+            << std::endl
+        ;
+        
+        // // DEBUG:
+        // auto buffer_str = std::string{
+        //     std::istreambuf_iterator< char >( this ),
+        //     {}
+        // };
+        // std::cout
+        //     << "multipart::segment::segment(): rest of buffer is \""
+        //     << __show::escape_seq( buffer_str )
+        //     << "\""
+        //     << std::endl
+        // ;
+        
+        // This is basically a miniature version of show::request::request()'s
+        // parsing that only handles headers; possibly they can be combined into
+        // a single utility function
+        
+        bool reading                   { true  };
+        // // Start at 1 because `multipart` constructor will strip first newline
+        // int  seq_newlines              { 1     };
+        int  seq_newlines              { 0     };
+        bool in_endline_seq            { false };
+        bool check_for_multiline_header{ false };
+        std::string key_buffer, value_buffer;
+        
+        enum {
+            READING_HEADER_NAME,
+            READING_HEADER_PADDING,
+            READING_HEADER_VALUE
+        } parse_state{ READING_HEADER_NAME };
+        
+        // DEBUG:
+        std::streamsize nth_char{ 0 };
+        
+        while( reading )
+        {
+            auto current_i = sbumpc();
+            
+            // if( traits_type::not_eof( current_i ) != current_i )
+            //     throw multipart_parse_error{
+            //         "premature end of multipart data while reading headers"
+            //     };
+            
+            auto current_char = traits_type::to_char_type( current_i );
+            
+            // DEBUG:
+            std::cout
+                << "multipart::segment::segment(): char "
+                << nth_char++
+                << " '"
+                << __show::escape_seq( { current_char } )
+                << "' ("
+                << static_cast< unsigned int >( current_char )
+                << ", "
+                << current_i
+                << ")"
+                << std::endl
+            ;
+            
+            if( in_endline_seq )
+            {
+                if( current_char == '\n' )
+                    in_endline_seq = false;
+                else
+                    throw multipart_parse_error{
+                        "malformed HTTP line ending in multipart data"
+                    };
+            }
+            
+            if( current_char == '\n' )
+                ++seq_newlines;
+            else if( current_char == '\r' )
+            {
+                in_endline_seq = true;
+                continue;
+            }
+            else
+                seq_newlines = 0;
+            
+            switch( parse_state )
+            {
+            case READING_HEADER_NAME:
+                {
+                    switch( current_char )
+                    {
+                    case ':':
+                        parse_state = READING_HEADER_PADDING;
+                        break;
+                    case '\n':
+                        if( key_buffer.size() < 1 )
+                        {
+                            // DEBUG:
+                            std::cout
+                                // << "done parsing headers, next char is '"
+                                // << __show::escape_seq( { traits_type::to_char_type( sgetc() ) } )
+                                // << "'"
+                                << "done parsing headers 1"
+                                << std::endl
+                            ;
+                            
+                            reading = false;
+                            break;
+                        }
+                    default:
+                        if( !(
+                               ( current_char >= 'a' && current_char <= 'z' )
+                            || ( current_char >= 'A' && current_char <= 'Z' )
+                            || ( current_char >= '0' && current_char <= '9' )
+                            || current_char == '-'
+                        ) )
+                            throw multipart_parse_error{
+                                "malformed header in multipart data"
+                            };
+                        
+                        key_buffer += current_char;
+                        break;
+                    }
+                }
+                break;
+                
+            case READING_HEADER_PADDING:
+                if( current_char == ' ' || current_char == '\t' )
+                {
+                    parse_state = READING_HEADER_VALUE;
+                    break;
+                }
+                else if( current_char == '\n' )
+                    parse_state = READING_HEADER_VALUE;
+                else
+                    throw multipart_parse_error{
+                        "malformed header in multipart data"
+                    };
+                
+            case READING_HEADER_VALUE:
+                {
+                    switch( current_char )
+                    {
+                    case '\n':
+                        if( seq_newlines >= 2 )
+                        {
+                            if( check_for_multiline_header )
+                            {
+                                if( value_buffer.size() < 1 )
+                                    throw multipart_parse_error{
+                                        "missing header value in multipart data"
+                                    };
+                                _headers[ key_buffer ].push_back(
+                                    value_buffer
+                                );
+                            }
+                            
+                            // DEBUG:
+                            std::cout
+                                // << "done parsing headers, next char is '"
+                                // << __show::escape_seq( { traits_type::to_char_type( sgetc() ) } )
+                                // << "'"
+                                << "done parsing headers 2"
+                                << std::endl
+                            ;
+                            
+                            reading = false;
+                        }
+                        else
+                            check_for_multiline_header = true;
+                        break;
+                    case ' ':
+                    case '\t':
+                        if( check_for_multiline_header )
+                            check_for_multiline_header = false;
+                        if(
+                            value_buffer.size() > 0
+                            && *value_buffer.rbegin() != ' '
+                        )
+                            value_buffer += ' ';
+                        break;
+                    default:
+                        if( check_for_multiline_header )
+                        {
+                            if( value_buffer.size() < 1 )
+                                throw multipart_parse_error{
+                                    "missing header value in multipart data"
+                                };
+                            
+                            _headers[ key_buffer ].push_back(
+                                value_buffer
+                            );
+                            
+                            // Start new key with current value
+                            key_buffer = current_char;
+                            value_buffer = "";
+                            check_for_multiline_header = false;
+                            
+                            parse_state = READING_HEADER_NAME;
+                        }
+                        else
+                        {
+                            value_buffer += current_char;
+                            check_for_multiline_header = false;
+                        }
+                        break;
+                    }
+                }
+                break;
+            }
+        }
+        
+        // // DEBUG:
+        // std::cout
+        //     << "multipart::segment::segment(): done, next char is '"
+        //     << __show::escape_seq( { traits_type::to_char_type( sgetc() ) } )
+        //     << "', eback - "
+        //     << gptr() - eback()
+        //     << " - gptr - "
+        //     << egptr() - gptr()
+        //     << " - egptr"
+        //     << std::endl
+        // ;
+    }
+    
+    inline multipart::segment& multipart::segment::operator =( segment&& o )
+    {
+        _parent   = o._parent;
+        _headers  = o._headers;
+        _buffer   = o._buffer;
+        _finished = o._finished;
+        // setg(
+        //     o.eback(),
+        //     o.gptr (),
+        //     o.egptr()
+        // );
+        
+        // Can't do this with std::swap() because that's not guaranteed to swap
+        // the strings' internal buffers, e.g. with small-string optimization.
+        // Non-cost std::string::data() only available in C++17
+        setg(
+            const_cast< char* >( _buffer.data() ) + ( o.eback() - o._buffer.data() ),
+            const_cast< char* >( _buffer.data() ) + ( o.gptr () - o._buffer.data() ),
+            const_cast< char* >( _buffer.data() ) + ( o.egptr() - o._buffer.data() )
+        );
+        
+        // DEBUG:
+        std::cout
+            << "multipart::segment::operator =(): _buffer.data() = "
+            << static_cast< const void* >( _buffer.data() )
+            << ", eback() = "
+            << static_cast< const void* >( eback() )
+            << std::endl
+        ;
+        
+        return *this;
+    }
+    
+    inline const headers_type& multipart::segment::headers()
+    {
+        return _headers;
+    }
+    
+    inline std::streamsize multipart::segment::showmanyc()
+    {
+        // No standard content length information, so this is only ever either
+        // "none" (-1) or "indeterminate" (0) (this is only called if the count
+        // cannot be derived from `gptr()` and `egptr()`)
+        if( _finished || _parent -> _buffer.in_avail() == -1 )
+            return -1;
+        else
+            return 0;
+    }
+    
+    inline multipart::segment::int_type multipart::segment::underflow()
+    {
+        // DEBUG:
+        std::cout
+            << "underflow(): gptr position is "
+            << gptr() - eback()
+            << "; "
+            << ( _finished ? "finished" : "not finished" )
+            << std::endl
+        ;
+        
+        if( _finished )
+            return traits_type::eof();
+        
+        // Non-cost std::string::data() only available in C++17
+        setg(
+            const_cast< char* >( _buffer.data() ),
+            const_cast< char* >( _buffer.data() ),
+            const_cast< char* >( _buffer.data() )
+        );
+        
+        auto boundary = "\r\n--" + _parent -> boundary();
+        
+        // DEBUG:
+        std::cout
+            << "underflow(): boundary size is "
+            << boundary.size()
+            << ", buffer size is "
+            << _buffer.size()
+            << std::endl
+        ;
+        
+        std::string::size_type next_boundary_char{ 0 };
+        do
+        {
+            auto got_i = _parent -> _buffer.sgetc();
+            
+            if( traits_type::not_eof( got_i ) != got_i )
+                throw multipart_parse_error{
+                    "premature end of multipart data"
+                };
+            
+            auto got_c = traits_type::to_char_type( got_i );
+            
+            
+            
+            if( got_c == boundary[ next_boundary_char ] )
+            {
+                ( *egptr() ) = got_c;
+                setg(
+                    eback(),
+                    gptr (),
+                    egptr() + 1
+                );
+                _parent -> _buffer.sbumpc();
+                
+                // DEBUG:
+                std::cout
+                    << "underflow(): got '"
+                    << __show::escape_seq( { got_c } )
+                    << "', putting into buffer; current buffer is \""
+                    << __show::escape_seq( _buffer )
+                    << "\" (\""
+                    << __show::escape_seq( _buffer.substr( 0, egptr() - eback() ) )
+                    << "\")"
+                    << std::endl
+                ;
+                
+                next_boundary_char += 1;
+            }
+            else if( next_boundary_char == 0 && got_c == '\n' )
+            {
+                ( *egptr() ) = got_c;
+                setg(
+                    eback(),
+                    gptr (),
+                    egptr() + 1
+                );
+                _parent -> _buffer.sbumpc();
+                
+                // DEBUG:
+                std::cout
+                    << "underflow(): got '"
+                    << __show::escape_seq( { got_c } )
+                    << "', putting into buffer; current buffer is \""
+                    << __show::escape_seq( _buffer )
+                    << "\" (\""
+                    << __show::escape_seq( _buffer.substr( 0, egptr() - eback() ) )
+                    << "\"); increment by 2"
+                    << std::endl
+                ;
+                
+                next_boundary_char += 2;
+            }
+            else
+            {
+                if( egptr() - eback() == 0 )
+                {
+                    ( *egptr() ) = got_c;
+                    setg(
+                        eback(),
+                        gptr (),
+                        egptr() + 1
+                    );
+                    _parent -> _buffer.sbumpc();
+                    
+                    // DEBUG:
+                    std::cout
+                        << "underflow(): got '"
+                        << __show::escape_seq( { got_c } )
+                        << "', putting into buffer; current buffer is \""
+                        << __show::escape_seq( _buffer )
+                        << "\" (\""
+                        << __show::escape_seq( _buffer.substr( 0, egptr() - eback() ) )
+                        << "\")"
+                        << std::endl
+                    ;
+                }
+                // DEBUG:
+                else
+                    std::cout
+                        << "underflow(): got '"
+                        << __show::escape_seq( { got_c } )
+                        << "', not putting into buffer; current buffer is \""
+                        << __show::escape_seq( _buffer )
+                        << "\" (\""
+                        << __show::escape_seq( _buffer.substr( 0, egptr() - eback() ) )
+                        << "\")"
+                        << std::endl
+                    ;
+                
+                return traits_type::to_int_type( _buffer[ 0 ] );
+            }
+            
+        #if 0
+            // Put character into buffer
+            ( *egptr() ) = got_c;
+            setg(
+                eback(),
+                gptr (),
+                egptr() + 1
+            );
+            
+            _parent -> _buffer.sbumpc();
+            
+            // DEBUG:
+            std::cout
+                << "underflow(): got '"
+                << __show::escape_seq( { got_c } )
+                << "' ("
+                << static_cast< unsigned int >( got_c )
+                << "), putting into buffer; current buffer is \""
+                << __show::escape_seq( _buffer )
+                << "\" (\""
+                << __show::escape_seq( _buffer.substr( 0, egptr() - eback() ) )
+                << "\")"
+                << std::endl
+            ;
+            
+            if( got_c == boundary[ next_boundary_char ] )
+            {
+                next_boundary_char += 1;
+            }
+            else if( next_boundary_char == 0 && got_c == '\n' )
+            {
+                next_boundary_char += 2;
+            }
+            else
+            {
+                // DEBUG:
+                std::cout
+                    << "underflow(): got char ('"
+                    << __show::escape_seq( { got_c } )
+                    << "') was not a boundary member, returning"
+                    << std::endl
+                ;
+                
+                return traits_type::to_int_type( _buffer[ 0 ] );
+            }
+        #endif
+            
+        #if 0
+            if(
+                egptr() - eback() == 0
+                || got_c == boundary[ next_boundary_char ]
+            )
+            {
+                ( *egptr() ) = got_c;
+                setg(
+                    eback(),
+                    gptr (),
+                    egptr() + 1
+                );
+                _parent -> _buffer.sbumpc();
+                
+                // DEBUG:
+                std::cout
+                    << "underflow(): putting '"
+                    << __show::escape_seq( { got_c } )
+                    << "' ("
+                    << static_cast< unsigned int >( got_c )
+                    << ") into buffer; current buffer is \""
+                    << __show::escape_seq( _buffer )
+                    << "\" (\""
+                    << __show::escape_seq( _buffer.substr( 0, egptr() - eback() ) )
+                    << "\")"
+                    << std::endl
+                ;
+                
+                if( got_c == boundary[ next_boundary_char ] )
+                    next_boundary_char += 1;
+                else if( next_boundary_char == 0 && got_c == '\n' )
+                    next_boundary_char += 2;
+                // else
+                //     break;
+                
+                // if( next_boundary_char == 0 && got_c == '\n' )
+                //     next_boundary_char += 2;
+                // else
+                //     next_boundary_char += 1;
+            }
+            else
+            {
+                // DEBUG:
+                std::cout
+                    << "underflow(): got '"
+                    << __show::escape_seq( { got_c } )
+                    << "' ("
+                    << static_cast< unsigned int >( got_c )
+                    << "), not putting in buffer; returning; current buffer is \""
+                    << __show::escape_seq( _buffer )
+                    << "\" (\""
+                    << __show::escape_seq( _buffer.substr( 0, egptr() - eback() ) )
+                    << "\")"
+                    << std::endl
+                ;
+                return traits_type::to_int_type( _buffer[ 0 ] );
+            }
+        #endif
+        // } while( next_boundary_char < boundary.size() );
+        } while( next_boundary_char < _buffer.size() );
+        
+        // DEBUG:
+        std::cout
+            << "underflow(): end of multipart segment detected"
+            << std::endl
+        ;
+        
+        auto  int_1 = _parent -> _buffer.sbumpc();
+        auto  int_2 = _parent -> _buffer.sgetc ();
+        auto char_1 = std::streambuf::traits_type::to_char_type( int_1 );
+        auto char_2 = std::streambuf::traits_type::to_char_type( int_2 );
+        
+        if(
+               std::streambuf::traits_type::not_eof( int_1 ) != int_1
+            || std::streambuf::traits_type::not_eof( int_2 ) != int_2
+        )
+            throw multipart_parse_error{
+                "premature end of multipart boundary"
+            };
+        else if( char_1 == '-' && char_2 == '-' )
+        {
+            // DEBUG:
+            std::cout
+                << "underflow(): end of multipart segment detected followed by \"--\", finishing parent"
+                << std::endl
+            ;
+            
+            _parent -> _buffer.sbumpc();
+            _parent -> _state = state::FINISHED;
+        }
+        else if( char_1 == '\r' && char_2 == '\n' )
+        {
+            // DEBUG:
+            std::cout
+                << "underflow(): end of multipart segment detected with a following segment"
+                << std::endl
+            ;
+            
+            _parent -> _buffer.sbumpc();
+        }
+        else if( char_1 != '\n' )
+            throw multipart_parse_error{
+                "malformed multipart boundary"
+            };
+        
+        _finished = true;
+        // Non-cost std::string::data() only available in C++17
+        setg(
+            const_cast< char* >( _buffer.data() ),
+            const_cast< char* >( _buffer.data() ),
+            const_cast< char* >( _buffer.data() )
+        );
+        return traits_type::eof();
+    }
+    
+    // inline std::streamsize multipart::segment::xsgetn(
+    //     multipart::segment::char_type* s,
+    //     std::streamsize count
+    // )
+    // {
+    //     
+    // }
+    
+    inline multipart::segment::int_type multipart::segment::pbackfail(
+        multipart::segment::int_type c
+    )
+    {
+        if( gptr() - eback() )
+        {
+            setg(
+                eback(),
+                gptr () - 1,
+                egptr()
+            );
+            
+            if( traits_type::not_eof( c ) == c )
+                *gptr() = traits_type::to_char_type( c );
+            
+            return traits_type::to_int_type( static_cast< char >( ASCII_ACK ) );
+        }
+        else
+            return traits_type::eof();
+    }
+    
+    // Iterator ----------------------------------------------------------------
+    
+    inline multipart::iterator::iterator( multipart& p, bool end ) :
+        _parent         { p     },
+        _is_end         { end   },
+        _locked         { false },
+        _segment_index  { 0     }
+    {
+        if( !end )
+            _current_segment = { p };
+    }
+    
+    inline multipart::iterator::iterator( const iterator& o ) :
+        _parent       { o._parent        },
+        _is_end       { o._is_end        },
+        _locked       { true             },
+        _segment_index{ o._segment_index }
+    {}
+    
+    inline multipart::iterator::reference multipart::iterator::operator *()
+    {
+        if( _is_end )
+            throw std::out_of_range{
+                "can't dereference show::multipart::iterator at end"
+            };
+        if( _locked )
+            throw std::logic_error{
+                "can't dereference show::multipart::iterator copy"
+            };
+        
+        return _current_segment;
+    }
+    
+    inline multipart::iterator::pointer multipart::iterator::operator ->()
+    {
+        return &( **this );
+    }
+    
+    inline multipart::iterator& multipart::iterator::operator ++()
+    {
+        // DEBUG:
+        std::cout
+            << "multipart::iterator::operator ++()"
+            << std::endl
+        ;
+        
+        if( _is_end )
+            throw std::out_of_range{
+                "can't increment show::multipart::iterator at end"
+            };
+        if( _locked )
+            throw std::logic_error{
+                "can't increment show::multipart::iterator copy"
+            };
+        
+        // DEBUG:
+        std::cout
+            << "multipart::iterator::operator ++(): flushing"
+            << std::endl
+        ;
+        
+        // Flush to end of current segment
+        segment::int_type bumped;
+        do
+        {
+            bumped = _current_segment.sbumpc();
+        } while( segment::traits_type::not_eof( bumped ) == bumped );
+        
+        // DEBUG:
+        std::cout
+            << "multipart::iterator::operator ++(): done flushing"
+            << std::endl
+        ;
+        
+        // TODO: needs to know parent state (or at least if finished)
+        ++_segment_index;
+        if( _parent._state == state::FINISHED )
+        {
+            _is_end = true;
+            _current_segment = {};
+        }
+        else
+            _current_segment = { _parent };
+        
+        return *this;
+    }
+    
+    inline multipart::iterator multipart::iterator::operator ++( int )
+    {
+        auto copy = *this;
+        ++( *this );
+        return copy;
+    }
+    
+    inline bool multipart::iterator::operator ==( const iterator& o ) const
+    {
+        if( &_parent._buffer != &o._parent._buffer )
+            return false;
+        else if( _is_end && o._is_end )
+            return true;
+        else if( !_is_end && !o._is_end )
+            return _segment_index == o._segment_index;
+        else
+            return false;
+    }
+    
+    // Multipart ---------------------------------------------------------------
+    
+    template< class String > multipart::multipart(
+        std::streambuf& b,
+        String&& boundary
+    ) :
+        _buffer  { b                                  },
+        // _begun   { false                              },
+        _boundary{ std::forward< String >( boundary ) },
+        _state   { state::READY                       }
+    {
+        if( _boundary.size() < 1 )
+            throw std::invalid_argument( "empty string as multipart boundary" );
+        
+        // Multipart data starts with a boundary, so flush that out to simplify
+        // parsing the rest
+        std::string got_boundary( _boundary.size() + 2, '\0' );
+        if(
+            _buffer.sgetn(
+                // Non-cost std::string::data() only available in C++17
+                const_cast< char* >( got_boundary.data() ),
+                _boundary.size() + 2
+            ) < _boundary.size() + 2
+            || got_boundary != "--" + _boundary
+        )
+        {
+            // DEBUG:
+            std::cout
+                << "multipart::multipart(): got boundary \""
+                << __show::escape_seq( got_boundary )
+                << "\", expected \""
+                << __show::escape_seq( "--" + _boundary )
+                << "\""
+                << std::endl
+            ;
+            
+            throw multipart_parse_error(
+                "multipart data did not start with boundary sequence"
+            );
+        }
+        else
+        {
+            auto  int_1 = _buffer.sbumpc();
+            auto  int_2 = _buffer.sgetc ();
+            auto char_1 = std::streambuf::traits_type::to_char_type( int_1 );
+            auto char_2 = std::streambuf::traits_type::to_char_type( int_2 );
+            
+            if(
+                   std::streambuf::traits_type::not_eof( int_1 ) != int_1
+                || std::streambuf::traits_type::not_eof( int_2 ) != int_2
+            )
+                throw multipart_parse_error{
+                    "premature end of first multipart boundary"
+                };
+            else if( char_1 == '-' && char_2 == '-' )
+            {
+                // DEBUG:
+                std::cout
+                    << "multipart::multipart(): beginning boundary \""
+                    << __show::escape_seq( got_boundary )
+                    << __show::escape_seq( { char_1 } )
+                    << __show::escape_seq( { char_2 } )
+                    << "\""
+                    << std::endl
+                ;
+                
+                _buffer.sbumpc();
+                _state = state::FINISHED;
+            }
+            else if( char_1 == '\r' && char_2 == '\n' )
+            {
+                // DEBUG:
+                std::cout
+                    << "multipart::multipart(): beginning boundary \""
+                    << __show::escape_seq( got_boundary )
+                    << __show::escape_seq( { char_1 } )
+                    << __show::escape_seq( { char_2 } )
+                    << "\""
+                    << std::endl
+                ;
+                
+                _buffer.sbumpc();
+            }
+            else if( char_1 == '\n' )
+            {
+                // DEBUG:
+                std::cout
+                    << "multipart::multipart(): beginning boundary \""
+                    << __show::escape_seq( got_boundary )
+                    << __show::escape_seq( { char_1 } )
+                    << "\""
+                    << std::endl
+                ;
+                
+                // _buffer.sbumpc();
+            }
+            else
+                throw multipart_parse_error{
+                    "malformed first multipart boundary"
+                };
+            // // DEBUG:
+            // else
+            //     // DEBUG:
+            //     std::cout
+            //         << "multipart::multipart(): beginning boundary \""
+            //         << __show::escape_seq( got_boundary )
+            //         << __show::escape_seq( { char_1 } )
+            //         << __show::escape_seq( { char_2 } )
+            //         << "\""
+            //         << std::endl
+            //     ;
+        }
+        
+        // // DEBUG:
+        // auto buffer_str = std::string{
+        //     std::istreambuf_iterator< char >( &_buffer ),
+        //     {}
+        // };
+        // std::cout
+        //     << "multipart::multipart(): rest of buffer is \""
+        //     << __show::escape_seq( buffer_str )
+        //     << "\""
+        //     << std::endl
+        // ;
+    }
+    
+    inline const std::streambuf& multipart::buffer()
+    {
+        return _buffer;
+    }
+    
+    inline const std::string& multipart::boundary()
+    {
+        return _boundary;
+    }
+    
+    inline multipart::iterator multipart::begin()
+    {
+        // // DEBUG:
+        // std::cout
+        //     << "multipart::begin(): _begun = "
+        //     << _begun
+        //     << std::endl
+        // ;
+        
+        if( _state != state::BEGUN )
+        {
+            if( _state == state::READY )
+                _state = state::BEGUN;
+            
+            return iterator{
+                *this,
+                // `begin()` == `end()` if there are no segments
+                _state == state::FINISHED
+            };
+        }
+        else
+            throw std::logic_error{ "already iterating over show::multipart" };
+    }
+    
+    inline multipart::iterator multipart::end()
+    {
+        return iterator{ *this, true };
+    }
+}
+
+
+#endif

--- a/src/show/multipart.hpp
+++ b/src/show/multipart.hpp
@@ -158,9 +158,7 @@ namespace show
         
         while( reading )
         {
-            auto current_i = sbumpc();
-            
-            auto current_char = traits_type::to_char_type( current_i );
+            auto current_char{ traits_type::to_char_type( sbumpc() ) };
             
             if( in_endline_seq )
             {
@@ -338,19 +336,19 @@ namespace show
             const_cast< char* >( _buffer.data() )
         );
         
-        auto boundary = "\r\n--" + _parent -> boundary();
+        auto boundary{ "\r\n--" + _parent -> boundary() };
         
         std::string::size_type next_boundary_char{ 0 };
         do
         {
-            auto got_i = _parent -> _buffer -> sgetc();
+            auto got_i{ _parent -> _buffer -> sgetc() };
             
             if( traits_type::not_eof( got_i ) != got_i )
                 throw multipart_parse_error{
                     "premature end of multipart data"
                 };
             
-            auto got_c = traits_type::to_char_type( got_i );
+            auto got_c{ traits_type::to_char_type( got_i ) };
             
             if(
                 got_c == boundary[ next_boundary_char ]
@@ -376,10 +374,10 @@ namespace show
             
         } while( next_boundary_char < _buffer.size() );
         
-        auto  int_1 = _parent -> _buffer -> sbumpc();
-        auto  int_2 = _parent -> _buffer -> sgetc ();
-        auto char_1 = std::streambuf::traits_type::to_char_type( int_1 );
-        auto char_2 = std::streambuf::traits_type::to_char_type( int_2 );
+        auto  int_1{ _parent -> _buffer -> sbumpc()                     };
+        auto  int_2{ _parent -> _buffer -> sgetc ()                     };
+        auto char_1{ std::streambuf::traits_type::to_char_type( int_1 ) };
+        auto char_2{ std::streambuf::traits_type::to_char_type( int_2 ) };
         
         if(
                std::streambuf::traits_type::not_eof( int_1 ) != int_1
@@ -536,7 +534,7 @@ namespace show
         _state   { state::READY                       }
     {
         if( _boundary.size() < 1 )
-            throw std::invalid_argument( "empty string as multipart boundary" );
+            throw std::invalid_argument{ "empty string as multipart boundary" };
         
         // Multipart data starts with a boundary, so flush that out to simplify
         // parsing the rest
@@ -554,10 +552,10 @@ namespace show
             );
         else
         {
-            auto  int_1 = _buffer -> sbumpc();
-            auto  int_2 = _buffer -> sgetc ();
-            auto char_1 = std::streambuf::traits_type::to_char_type( int_1 );
-            auto char_2 = std::streambuf::traits_type::to_char_type( int_2 );
+            auto  int_1{ _buffer -> sbumpc()                                };
+            auto  int_2{ _buffer -> sgetc ()                                };
+            auto char_1{ std::streambuf::traits_type::to_char_type( int_1 ) };
+            auto char_2{ std::streambuf::traits_type::to_char_type( int_2 ) };
             
             if(
                    std::streambuf::traits_type::not_eof( int_1 ) != int_1

--- a/src/show/multipart.hpp
+++ b/src/show/multipart.hpp
@@ -94,6 +94,7 @@ namespace show
             iterator& operator ++(                 );
             iterator  operator ++( int             );
             bool      operator ==( const iterator& ) const;
+            bool      operator !=( const iterator& ) const;
         };
         
         template< class String > multipart(
@@ -517,6 +518,11 @@ namespace show
             return _segment_index == o._segment_index;
         else
             return false;
+    }
+    
+    inline bool multipart::iterator::operator !=( const iterator& o ) const
+    {
+        return !( *this == o );
     }
     
     // Multipart ---------------------------------------------------------------

--- a/src/show/multipart.hpp
+++ b/src/show/multipart.hpp
@@ -351,46 +351,28 @@ namespace show
             
             auto got_c = traits_type::to_char_type( got_i );
             
-            // TODO: Cleanup
+            if(
+                got_c == boundary[ next_boundary_char ]
+                || ( next_boundary_char == 0 && got_c == '\n' )
+                || egptr() - eback() == 0
+            )
+            {
+                ( *egptr() ) = got_c;
+                setg(
+                    eback(),
+                    gptr (),
+                    egptr() + 1
+                );
+                _parent -> _buffer.sbumpc();
+            }
+            
             if( got_c == boundary[ next_boundary_char ] )
-            {
-                ( *egptr() ) = got_c;
-                setg(
-                    eback(),
-                    gptr (),
-                    egptr() + 1
-                );
-                _parent -> _buffer.sbumpc();
-                
                 next_boundary_char += 1;
-            }
             else if( next_boundary_char == 0 && got_c == '\n' )
-            {
-                ( *egptr() ) = got_c;
-                setg(
-                    eback(),
-                    gptr (),
-                    egptr() + 1
-                );
-                _parent -> _buffer.sbumpc();
-                
                 next_boundary_char += 2;
-            }
             else
-            {
-                if( egptr() - eback() == 0 )
-                {
-                    ( *egptr() ) = got_c;
-                    setg(
-                        eback(),
-                        gptr (),
-                        egptr() + 1
-                    );
-                    _parent -> _buffer.sbumpc();
-                }
-                
                 return traits_type::to_int_type( _buffer[ 0 ] );
-            }
+            
         } while( next_boundary_char < _buffer.size() );
         
         auto  int_1 = _parent -> _buffer.sbumpc();

--- a/tests/UnitTest++_wrap.hpp
+++ b/tests/UnitTest++_wrap.hpp
@@ -7,6 +7,7 @@
 #include <sstream>
 
 #include <show.hpp>
+#include <show/multipart.hpp>
 
 
 std::string escape_seq( const std::string& s );
@@ -24,6 +25,10 @@ std::ostream& operator<<(
 );
 std::ostream& operator<<( std::ostream& out, const show::query_args_type& v );
 std::ostream& operator<<( std::ostream& out, const show::headers_type& v );
+std::ostream& operator<<(
+    std::ostream& out,
+    const show::multipart::iterator& iter
+);
 
 
 #include <UnitTest++/UnitTest++.h>

--- a/tests/multipart_tests.cpp
+++ b/tests/multipart_tests.cpp
@@ -33,12 +33,12 @@ SUITE( ShowMultipartTests )
 {
     TEST( MoveConstructMultipart )
     {
-        auto make_multipart = [](
+        auto make_multipart{ [](
             std::stringbuf& buffer,
             const std::string& boundary
         ){
             return show::multipart{ buffer, boundary };
-        };
+        } };
         
         std::stringbuf content{
             (
@@ -50,8 +50,8 @@ SUITE( ShowMultipartTests )
             std::ios::in
         };
         
-        show::multipart test_multipart = make_multipart( content, boundaryA );
-        auto iter = test_multipart.begin();
+        auto test_multipart{ make_multipart( content, boundaryA ) };
+        auto iter          { test_multipart.begin()               };
         
         CHECK_EQUAL(
             ( show::headers_type{} ),
@@ -60,7 +60,7 @@ SUITE( ShowMultipartTests )
         CHECK_EQUAL(
             "hello world",
             ( std::string{
-                std::istreambuf_iterator< char >( &*iter ),
+                std::istreambuf_iterator< char >{ &*iter },
                 {}
             } )
         );
@@ -73,12 +73,12 @@ SUITE( ShowMultipartTests )
     
     TEST( MoveAssignMultipart )
     {
-        auto make_multipart = [](
+        auto make_multipart{ [](
             std::stringbuf& buffer,
             const std::string& boundary
         ){
             return show::multipart{ buffer, boundary };
-        };
+        } };
         
         std::stringbuf content1{
             (
@@ -89,8 +89,8 @@ SUITE( ShowMultipartTests )
             ),
             std::ios::in
         };
-        show::multipart test_multipart = make_multipart( content1, boundaryA );
-        auto iter1 = test_multipart.begin();
+        auto test_multipart{ make_multipart( content1, boundaryA ) };
+        auto iter1         { test_multipart.begin()                };
         
         CHECK_EQUAL(
             ( show::headers_type{} ),
@@ -99,7 +99,7 @@ SUITE( ShowMultipartTests )
         CHECK_EQUAL(
             "hello world",
             ( std::string{
-                std::istreambuf_iterator< char >( &*iter1 ),
+                std::istreambuf_iterator< char >{ &*iter1 },
                 {}
             } )
         );
@@ -120,7 +120,7 @@ SUITE( ShowMultipartTests )
             std::ios::in
         };
         test_multipart = make_multipart( content2, boundaryA );
-        auto iter2 = test_multipart.begin();
+        auto iter2{ test_multipart.begin() };
         
         CHECK_EQUAL(
             ( show::headers_type{ { "Content-Type", { "text/plain" } } } ),
@@ -129,7 +129,7 @@ SUITE( ShowMultipartTests )
         CHECK_EQUAL(
             "foo bar",
             ( std::string{
-                std::istreambuf_iterator< char >( &*iter2 ),
+                std::istreambuf_iterator< char >{ &*iter2 },
                 {}
             } )
         );
@@ -142,12 +142,12 @@ SUITE( ShowMultipartTests )
     
     TEST( MoveConstructIterator )
     {
-        auto make_begin_iterator = []( show::multipart& m ){
+        auto make_begin_iterator{ []( show::multipart& m ){
             return m.begin();
-        };
-        auto make_end_iterator = []( show::multipart& m ){
+        } };
+        auto make_end_iterator{ []( show::multipart& m ){
             return m.end();
-        };
+        } };
         
         std::stringbuf content{
             (
@@ -160,7 +160,7 @@ SUITE( ShowMultipartTests )
         };
         
         show::multipart test_multipart{ content, boundaryA };
-        auto iter = make_begin_iterator( test_multipart );
+        auto iter{ make_begin_iterator( test_multipart ) };
         
         CHECK_EQUAL(
             ( show::headers_type{} ),
@@ -169,12 +169,12 @@ SUITE( ShowMultipartTests )
         CHECK_EQUAL(
             "hello world",
             ( std::string{
-                std::istreambuf_iterator< char >( &*iter ),
+                std::istreambuf_iterator< char >{ &*iter },
                 {}
             } )
         );
         ++iter;
-        auto end_iter = make_end_iterator( test_multipart );
+        auto end_iter{ make_end_iterator( test_multipart ) };
         CHECK_EQUAL(
             end_iter,
             test_multipart.end()
@@ -187,12 +187,12 @@ SUITE( ShowMultipartTests )
     
     TEST( MoveAssignIterator )
     {
-        auto make_begin_iterator = []( show::multipart& m ){
+        auto make_begin_iterator{ []( show::multipart& m ){
             return m.begin();
-        };
-        auto make_end_iterator = []( show::multipart& m ){
+        } };
+        auto make_end_iterator{ []( show::multipart& m ){
             return m.end();
-        };
+        } };
         
         std::stringbuf content1{
             (
@@ -217,7 +217,7 @@ SUITE( ShowMultipartTests )
         };
         show::multipart test_multipart2{ content2, boundaryA };
         
-        auto iter = test_multipart1.begin();
+        auto iter{ test_multipart1.begin() };
         
         CHECK_EQUAL(
             ( show::headers_type{} ),
@@ -226,7 +226,7 @@ SUITE( ShowMultipartTests )
         CHECK_EQUAL(
             "hello world",
             ( std::string{
-                std::istreambuf_iterator< char >( &*iter ),
+                std::istreambuf_iterator< char >{ &*iter },
                 {}
             } )
         );
@@ -240,7 +240,7 @@ SUITE( ShowMultipartTests )
         CHECK_EQUAL(
             "foo bar",
             ( std::string{
-                std::istreambuf_iterator< char >( &*iter ),
+                std::istreambuf_iterator< char >{ &*iter },
                 {}
             } )
         );
@@ -266,7 +266,7 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto iter = test_multipart.begin();
+        auto iter{ test_multipart.begin() };
         
         CHECK_EQUAL(
             test_multipart.end(),
@@ -289,7 +289,7 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto iter = test_multipart.begin();
+        auto iter{ test_multipart.begin() };
         
         CHECK_EQUAL(
             test_multipart.end(),
@@ -313,13 +313,13 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto iter = test_multipart.begin();
+        auto iter{ test_multipart.begin() };
         
         CHECK_EQUAL(
             ( show::headers_type{} ),
             iter -> headers()
         );
-        auto got_c = iter -> sgetc();
+        auto got_c{ iter -> sgetc() };
         CHECK(
             show::multipart::segment::traits_type::not_eof( got_c ) != got_c
         );
@@ -342,7 +342,7 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto iter = test_multipart.begin();
+        auto iter{ test_multipart.begin() };
         
         CHECK_EQUAL(
             ( show::headers_type{
@@ -350,7 +350,7 @@ SUITE( ShowMultipartTests )
             } ),
             iter -> headers()
         );
-        auto got_c = iter -> sgetc();
+        auto got_c{ iter -> sgetc() };
         CHECK(
             show::multipart::segment::traits_type::not_eof( got_c ) != got_c
         );
@@ -375,7 +375,7 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto iter = test_multipart.begin();
+        auto iter{ test_multipart.begin() };
         
         CHECK_EQUAL(
             ( show::headers_type{
@@ -385,7 +385,7 @@ SUITE( ShowMultipartTests )
             } ),
             iter -> headers()
         );
-        auto got_c = iter -> sgetc();
+        auto got_c{ iter -> sgetc() };
         CHECK(
             show::multipart::segment::traits_type::not_eof( got_c ) != got_c
         );
@@ -407,7 +407,7 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto iter = test_multipart.begin();
+        auto iter{ test_multipart.begin() };
         
         CHECK_EQUAL(
             ( show::headers_type{} ),
@@ -417,7 +417,7 @@ SUITE( ShowMultipartTests )
         CHECK_EQUAL(
             "hello world",
             ( std::string{
-                std::istreambuf_iterator< char >( &*iter ),
+                std::istreambuf_iterator< char >{ &*iter },
                 {}
             } )
         );
@@ -447,7 +447,7 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto iter = test_multipart.begin();
+        auto iter{ test_multipart.begin() };
         
         CHECK_EQUAL(
             ( show::headers_type{
@@ -456,7 +456,7 @@ SUITE( ShowMultipartTests )
             } ),
             iter -> headers()
         );
-        auto got_c = iter -> sgetc();
+        auto got_c{ iter -> sgetc() };
         CHECK(
             show::multipart::segment::traits_type::not_eof( got_c ) != got_c
         );
@@ -479,7 +479,7 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto iter = test_multipart.begin();
+        auto iter{ test_multipart.begin() };
         
         CHECK_EQUAL(
             ( show::headers_type{
@@ -487,7 +487,7 @@ SUITE( ShowMultipartTests )
             } ),
             iter -> headers()
         );
-        auto got_c = iter -> sgetc();
+        auto got_c{ iter -> sgetc() };
         CHECK(
             show::multipart::segment::traits_type::not_eof( got_c ) != got_c
         );
@@ -512,7 +512,7 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto iter = test_multipart.begin();
+        auto iter{ test_multipart.begin() };
         
         CHECK_EQUAL(
             ( show::headers_type{
@@ -522,7 +522,7 @@ SUITE( ShowMultipartTests )
             } ),
             iter -> headers()
         );
-        auto got_c = iter -> sgetc();
+        auto got_c{ iter -> sgetc() };
         CHECK(
             show::multipart::segment::traits_type::not_eof( got_c ) != got_c
         );
@@ -547,7 +547,7 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto iter = test_multipart.begin();
+        auto iter{ test_multipart.begin() };
         
         CHECK_EQUAL(
             ( show::headers_type{
@@ -557,7 +557,7 @@ SUITE( ShowMultipartTests )
             } ),
             iter -> headers()
         );
-        auto got_c = iter -> sgetc();
+        auto got_c{ iter -> sgetc() };
         
         CHECK(
             show::multipart::segment::traits_type::not_eof( got_c ) != got_c
@@ -585,7 +585,7 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto iter = test_multipart.begin();
+        auto iter{ test_multipart.begin() };
         
         CHECK_EQUAL(
             ( show::headers_type{
@@ -596,7 +596,7 @@ SUITE( ShowMultipartTests )
             } ),
             iter -> headers()
         );
-        auto got_c = iter -> sgetc();
+        auto got_c{ iter -> sgetc() };
         CHECK(
             show::multipart::segment::traits_type::not_eof( got_c ) != got_c
         );
@@ -623,7 +623,7 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto iter = test_multipart.begin();
+        auto iter{ test_multipart.begin() };
         
         CHECK_EQUAL(
             ( show::headers_type{
@@ -634,7 +634,7 @@ SUITE( ShowMultipartTests )
             } ),
             iter -> headers()
         );
-        auto got_c = iter -> sgetc();
+        auto got_c{ iter -> sgetc() };
         CHECK(
             show::multipart::segment::traits_type::not_eof( got_c ) != got_c
         );
@@ -662,7 +662,7 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto iter = test_multipart.begin();
+        auto iter{ test_multipart.begin() };
         
         CHECK_EQUAL(
             ( show::headers_type{
@@ -673,7 +673,7 @@ SUITE( ShowMultipartTests )
             } ),
             iter -> headers()
         );
-        auto got_c = iter -> sgetc();
+        auto got_c{ iter -> sgetc() };
         CHECK(
             show::multipart::segment::traits_type::not_eof( got_c ) != got_c
         );
@@ -703,12 +703,12 @@ SUITE( ShowMultipartTests )
                     test_request,
                     boundaryA
                 };
-                auto iter = test_multipart.begin();
+                auto iter{ test_multipart.begin() };
                 
                 CHECK_EQUAL(
                     "Hello World!",
                     ( std::string{
-                        std::istreambuf_iterator< char >( &*iter ),
+                        std::istreambuf_iterator< char >{ &*iter },
                         {}
                     } )
                 );
@@ -739,7 +739,7 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto iter = test_multipart.begin();
+        auto iter{ test_multipart.begin() };
         
         CHECK_EQUAL(
             ( show::headers_type{
@@ -750,7 +750,7 @@ SUITE( ShowMultipartTests )
         CHECK_EQUAL(
             "",
             ( std::string{
-                std::istreambuf_iterator< char >( &*iter ),
+                std::istreambuf_iterator< char >{ &*iter },
                 {}
             } )
         );
@@ -763,7 +763,7 @@ SUITE( ShowMultipartTests )
         CHECK_EQUAL(
             "foo bar",
             ( std::string{
-                std::istreambuf_iterator< char >( &*iter ),
+                std::istreambuf_iterator< char >{ &*iter },
                 {}
             } )
         );
@@ -776,7 +776,7 @@ SUITE( ShowMultipartTests )
         CHECK_EQUAL(
             "hello world",
             ( std::string{
-                std::istreambuf_iterator< char >( &*iter ),
+                std::istreambuf_iterator< char >{ &*iter },
                 {}
             } )
         );
@@ -821,7 +821,7 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto iter_A = test_multipart_A.begin();
+        auto iter_A{ test_multipart_A.begin() };
         CHECK_EQUAL(
             ( show::headers_type{
                 { "Content-Disposition", {
@@ -833,7 +833,7 @@ SUITE( ShowMultipartTests )
         CHECK_EQUAL(
             "foo bar",
             ( std::string{
-                std::istreambuf_iterator< char >( &*iter_A ),
+                std::istreambuf_iterator< char >{ &*iter_A },
                 {}
             } )
         );
@@ -852,7 +852,7 @@ SUITE( ShowMultipartTests )
                 *iter_A,
                 boundaryB
             };
-            auto iter_B = test_multipart_B.begin();
+            auto iter_B{ test_multipart_B.begin() };
             CHECK_EQUAL(
                 ( show::headers_type{
                     { "Content-Disposition", {
@@ -864,7 +864,7 @@ SUITE( ShowMultipartTests )
             CHECK_EQUAL(
                 "hello world",
                 ( std::string{
-                    std::istreambuf_iterator< char >( &*iter_B ),
+                    std::istreambuf_iterator< char >{ &*iter_B },
                     {}
                 } )
             );
@@ -883,7 +883,7 @@ SUITE( ShowMultipartTests )
                     *iter_B,
                     boundaryC
                 };
-                auto iter_C = test_multipart_C.begin();
+                auto iter_C{ test_multipart_C.begin() };
                 CHECK_EQUAL(
                     ( show::headers_type{
                         { "Content-Disposition", {
@@ -895,7 +895,7 @@ SUITE( ShowMultipartTests )
                 CHECK_EQUAL(
                     "qwerty",
                     ( std::string{
-                        std::istreambuf_iterator< char >( &*iter_C ),
+                        std::istreambuf_iterator< char >{ &*iter_C },
                         {}
                     } )
                 );
@@ -939,14 +939,14 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto iter = test_multipart.begin();
+        auto iter{ test_multipart.begin() };
         
         ++iter;
         
         CHECK_EQUAL(
             "hello world",
             ( std::string{
-                std::istreambuf_iterator< char >( &*iter ),
+                std::istreambuf_iterator< char >{ &*iter },
                 {}
             } )
         );
@@ -997,11 +997,11 @@ SUITE( ShowMultipartTests )
         };
         
         show::multipart test_multipart{ content, boundaryA };
-        auto iter = test_multipart.begin();
+        auto iter{ test_multipart.begin() };
         try
         {
             auto segment_content = std::string{
-                std::istreambuf_iterator< char >( &*iter ),
+                std::istreambuf_iterator< char >{ &*iter },
                 {}
             };
             CHECK( false );
@@ -1112,7 +1112,7 @@ SUITE( ShowMultipartTests )
         };
         try
         {
-            auto iter = test_multipart.begin();
+            auto iter{ test_multipart.begin() };
             CHECK( false );
         }
         catch( const show::multipart_parse_error& e )
@@ -1144,7 +1144,7 @@ SUITE( ShowMultipartTests )
         };
         try
         {
-            auto iter = test_multipart.begin();
+            auto iter{ test_multipart.begin() };
             CHECK( false );
         }
         catch( const show::multipart_parse_error& e )
@@ -1175,7 +1175,7 @@ SUITE( ShowMultipartTests )
         };
         try
         {
-            auto iter = test_multipart.begin();
+            auto iter{ test_multipart.begin() };
             CHECK( false );
         }
         catch( const show::multipart_parse_error& e )
@@ -1206,7 +1206,7 @@ SUITE( ShowMultipartTests )
         };
         try
         {
-            auto iter = test_multipart.begin();
+            auto iter{ test_multipart.begin() };
             CHECK( false );
         }
         catch( const show::multipart_parse_error& e )
@@ -1237,7 +1237,7 @@ SUITE( ShowMultipartTests )
         };
         try
         {
-            auto iter = test_multipart.begin();
+            auto iter{ test_multipart.begin() };
             CHECK( false );
         }
         catch( const show::multipart_parse_error& e )
@@ -1265,11 +1265,11 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto iter1 = test_multipart.begin();
+        auto iter1{ test_multipart.begin() };
         
         try
         {
-            auto iter2 = test_multipart.begin();
+            auto iter2{ test_multipart.begin() };
             CHECK( false );
         }
         catch( const std::logic_error& e )
@@ -1297,11 +1297,11 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto end_iter = test_multipart.end();
+        auto end_iter{ test_multipart.end() };
         
         try
         {
-            auto& segment = *end_iter;
+            auto& segment{ *end_iter };
             CHECK( false );
         }
         catch( const std::logic_error& e )
@@ -1329,7 +1329,7 @@ SUITE( ShowMultipartTests )
             content,
             boundaryA
         };
-        auto end_iter = test_multipart.end();
+        auto end_iter{ test_multipart.end() };
         
         try
         {

--- a/tests/multipart_tests.cpp
+++ b/tests/multipart_tests.cpp
@@ -1,0 +1,1178 @@
+#include "UnitTest++_wrap.hpp"
+#include <show/multipart.hpp>
+
+#include <sstream>
+#include <string>
+
+#include "async_utils.hpp"
+#include "constants.hpp"
+
+
+namespace
+{
+    // Stolen from https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.2
+    const std::string boundaryA{ "AaB03x" };
+    const std::string boundaryB{ "BbC04y" };
+    const std::string boundaryC{ "CcD05z" };
+}
+
+std::ostream& operator<<(
+    std::ostream& out,
+    const show::multipart::iterator& iter
+)
+{
+    return out
+        << "<show::multipart::iterator@"
+        << static_cast< const void* >( &iter )
+        << ">"
+    ;
+}
+
+
+SUITE( ShowMultipartTests )
+{
+    TEST( NoSegments )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        auto iter = test_multipart.begin();
+        
+        CHECK_EQUAL(
+            test_multipart.end(),
+            iter
+        );
+    }
+    
+    TEST( NoHeadersEmptyData )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "\r\n"
+                "\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        auto iter = test_multipart.begin();
+        
+        CHECK_EQUAL(
+            ( show::headers_type{} ),
+            iter -> headers()
+        );
+        auto got_c = iter -> sgetc();
+        CHECK(
+            show::multipart::segment::traits_type::not_eof( got_c ) != got_c
+        );
+    }
+    
+    TEST( SingleHeaderEmptyData )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Content-Disposition: form-data; name=\"some-text\"\r\n"
+                "\r\n"
+                "\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        auto iter = test_multipart.begin();
+        
+        CHECK_EQUAL(
+            ( show::headers_type{
+                { "Content-Disposition", { "form-data; name=\"some-text\"" } }
+            } ),
+            iter -> headers()
+        );
+        auto got_c = iter -> sgetc();
+        CHECK(
+            show::multipart::segment::traits_type::not_eof( got_c ) != got_c
+        );
+    }
+    
+    TEST( MultipleHeadersEmptyData )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Content-Disposition: form-data; name=\"some-text\"\r\n"
+                "Content-Type: image/gif\r\n"
+                "Content-Transfer-Encoding: binary\r\n"
+                "\r\n"
+                "\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        auto iter = test_multipart.begin();
+        
+        CHECK_EQUAL(
+            ( show::headers_type{
+                { "Content-Disposition"      , { "form-data; name=\"some-text\"" } },
+                { "Content-Type"             , { "image/gif"                     } },
+                { "Content-Transfer-Encoding", { "binary"                        } }
+            } ),
+            iter -> headers()
+        );
+        auto got_c = iter -> sgetc();
+        CHECK(
+            show::multipart::segment::traits_type::not_eof( got_c ) != got_c
+        );
+    }
+    
+    TEST( NoHeadersWithData )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "\r\n"
+                "hello world\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        auto iter = test_multipart.begin();
+        
+        CHECK_EQUAL(
+            ( show::headers_type{} ),
+            iter -> headers()
+        );
+        
+        // // DEBUG:
+        // std::string message;
+        // while( true )
+        // {
+        //     auto got_i = iter -> sbumpc();
+        //     auto got_c = std::streambuf::traits_type::to_char_type( got_i );
+            
+        //     if( std::streambuf::traits_type::not_eof( got_i ) != got_i )
+        //     {
+        //         std::cout
+        //             << "TEST( NoHeadersWithData ): eof, message is \""
+        //             << __show::escape_seq( message )
+        //             << "\""
+        //             << std::endl
+        //             << std::endl
+        //         ;
+        //         break;
+        //     }
+            
+        //     message += got_c;
+            
+        //     std::cout
+        //         << "TEST( NoHeadersWithData ): got char '"
+        //         << __show::escape_seq( { got_c } )
+        //         << "', message is \""
+        //         << __show::escape_seq( message )
+        //         << "\""
+        //         << std::endl
+        //         << std::endl
+        //     ;
+        // }
+        // CHECK_EQUAL(
+        //     "hello world",
+        //     message
+        // );
+        
+        CHECK_EQUAL(
+            "hello world",
+            ( std::string{
+                std::istreambuf_iterator< char >( &*iter ),
+                {}
+            } )
+        );
+        ++iter;
+        CHECK_EQUAL(
+            test_multipart.end(),
+            iter
+        );
+    }
+    
+    TEST( DuplicateHeaders )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Content-Disposition: form-data; name=\"some-text\"\r\n"
+                "Duplicate-Header: value 1\r\n"
+                "Duplicate-Header: value 2\r\n"
+                "\r\n"
+                "\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        auto iter = test_multipart.begin();
+        
+        CHECK_EQUAL(
+            ( show::headers_type{
+                { "Content-Disposition", { "form-data; name=\"some-text\"" } },
+                { "Duplicate-Header"   , { "value 1", "value 2"            } },
+            } ),
+            iter -> headers()
+        );
+        auto got_c = iter -> sgetc();
+        CHECK(
+            show::multipart::segment::traits_type::not_eof( got_c ) != got_c
+        );
+    }
+    
+    TEST( ExtraHeaderWhitespace )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Content-Disposition: \t   form-data; name=\"some-text\"\r\n"
+                "\r\n"
+                "\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        auto iter = test_multipart.begin();
+        
+        CHECK_EQUAL(
+            ( show::headers_type{
+                { "Content-Disposition", { "form-data; name=\"some-text\"" } }
+            } ),
+            iter -> headers()
+        );
+        auto got_c = iter -> sgetc();
+        CHECK(
+            show::multipart::segment::traits_type::not_eof( got_c ) != got_c
+        );
+    }
+    
+    TEST( PermissiveNewlinesInHeaders )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Content-Disposition: form-data; name=\"some-text\"\r\n"
+                "Content-Type: image/gif\n"
+                "Content-Transfer-Encoding: binary\n"
+                "\r\n"
+                "\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        auto iter = test_multipart.begin();
+        
+        CHECK_EQUAL(
+            ( show::headers_type{
+                { "Content-Disposition"      , { "form-data; name=\"some-text\"" } },
+                { "Content-Type"             , { "image/gif"                     } },
+                { "Content-Transfer-Encoding", { "binary"                        } }
+            } ),
+            iter -> headers()
+        );
+        auto got_c = iter -> sgetc();
+        CHECK(
+            show::multipart::segment::traits_type::not_eof( got_c ) != got_c
+        );
+    }
+    
+    TEST( PermissiveNewlinesInBoundary )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\n"
+                "Content-Disposition: form-data; name=\"some-text\"\r\n"
+                "Content-Type: image/gif\r\n"
+                "Content-Transfer-Encoding: binary\r\n"
+                "\r\n"
+                "\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        auto iter = test_multipart.begin();
+        
+        CHECK_EQUAL(
+            ( show::headers_type{
+                { "Content-Disposition"      , { "form-data; name=\"some-text\"" } },
+                { "Content-Type"             , { "image/gif"                     } },
+                { "Content-Transfer-Encoding", { "binary"                        } }
+            } ),
+            iter -> headers()
+        );
+        auto got_c = iter -> sgetc();
+        
+        // DEBUG:
+        std::cout
+            << "TEST( PermissiveNewlinesInBoundary ): got_c = "
+            << got_c
+            << ", not_eof = "
+            << show::multipart::segment::traits_type::not_eof( got_c )
+            << std::endl
+        ;
+        
+        CHECK(
+            show::multipart::segment::traits_type::not_eof( got_c ) != got_c
+        );
+    }
+    
+    TEST( MultiLineHeaderMiddle )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Content-Disposition: form-data; name=\"some-text\"\r\n"
+                "Content-Type: image/gif\r\n"
+                "Multi-Line-Header: part 1,\r\n"
+                "\tpart 2\r\n"
+                "Content-Transfer-Encoding: binary\r\n"
+                "\r\n"
+                "\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        auto iter = test_multipart.begin();
+        
+        CHECK_EQUAL(
+            ( show::headers_type{
+                { "Content-Disposition"      , { "form-data; name=\"some-text\"" } },
+                { "Content-Type"             , { "image/gif"                     } },
+                { "Content-Transfer-Encoding", { "binary"                        } },
+                { "Multi-Line-Header"        , { "part 1, part 2"                } }
+            } ),
+            iter -> headers()
+        );
+        auto got_c = iter -> sgetc();
+        CHECK(
+            show::multipart::segment::traits_type::not_eof( got_c ) != got_c
+        );
+    }
+    
+    TEST( MultiLineHeaderEnd )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Content-Disposition: form-data; name=\"some-text\"\r\n"
+                "Content-Type: image/gif\r\n"
+                "Content-Transfer-Encoding: binary\r\n"
+                "Multi-Line-Header: part 1,\r\n"
+                "\tpart 2\r\n"
+                "\r\n"
+                "\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        auto iter = test_multipart.begin();
+        
+        CHECK_EQUAL(
+            ( show::headers_type{
+                { "Content-Disposition"      , { "form-data; name=\"some-text\"" } },
+                { "Content-Type"             , { "image/gif"                     } },
+                { "Content-Transfer-Encoding", { "binary"                        } },
+                { "Multi-Line-Header"        , { "part 1, part 2"                } }
+            } ),
+            iter -> headers()
+        );
+        auto got_c = iter -> sgetc();
+        CHECK(
+            show::multipart::segment::traits_type::not_eof( got_c ) != got_c
+        );
+    }
+    
+    TEST( MultiLineHeaderEmptyFirstLineWithPadding )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Content-Disposition: form-data; name=\"some-text\"\r\n"
+                "Content-Type: image/gif\r\n"
+                "Multi-Line-Header:\t\r\n"
+                "  part 1,\r\n"
+                "\tpart 2\r\n"
+                "Content-Transfer-Encoding: binary\r\n"
+                "\r\n"
+                "\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        auto iter = test_multipart.begin();
+        
+        CHECK_EQUAL(
+            ( show::headers_type{
+                { "Content-Disposition"      , { "form-data; name=\"some-text\"" } },
+                { "Content-Type"             , { "image/gif"                     } },
+                { "Content-Transfer-Encoding", { "binary"                        } },
+                { "Multi-Line-Header"        , { "part 1, part 2"                } }
+            } ),
+            iter -> headers()
+        );
+        auto got_c = iter -> sgetc();
+        CHECK(
+            show::multipart::segment::traits_type::not_eof( got_c ) != got_c
+        );
+    }
+    
+    TEST( InitFromRequest )
+    {
+        std::string content{
+            "--" + boundaryA + "\r\n"
+            "Content-Disposition: form-data; name=\"some-text\"\r\n"
+            "Content-Type: text/plain\r\n"
+            "\r\n"
+            "Hello World!\r\n"
+            "--" + boundaryA + "--"
+        };
+        
+        run_checks_against_request(
+            (
+                "POST / HTTP/1.0\r\n"
+                "Content-Type: multipart/form-data; boundary=" + boundaryA + "\r\n"
+                "Content-Length: " + std::to_string( content.size() ) + "\r\n"
+                "\r\n"
+                + content
+            ),
+            []( show::request& test_request ){
+                show::multipart test_multipart{
+                    test_request,
+                    boundaryA
+                };
+                auto iter = test_multipart.begin();
+                
+                CHECK_EQUAL(
+                    "Hello World!",
+                    ( std::string{
+                        std::istreambuf_iterator< char >( &*iter ),
+                        {}
+                    } )
+                );
+            }
+        );
+    }
+    
+    TEST( ParseSegments )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Content-Disposition: form-data; name=\"some-text\"\r\n"
+                "\r\n"
+                "\r\n"
+                "--" + boundaryA + "\r\n"
+                + "\r\n"
+                "foo bar\r\n"
+                "--" + boundaryA + "\r\n"
+                + "\r\n"
+                "hello world\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        auto iter = test_multipart.begin();
+        
+        CHECK_EQUAL(
+            ( show::headers_type{
+                { "Content-Disposition", { "form-data; name=\"some-text\"" } }
+            } ),
+            iter -> headers()
+        );
+        CHECK_EQUAL(
+            "",
+            ( std::string{
+                std::istreambuf_iterator< char >( &*iter ),
+                {}
+            } )
+        );
+        ++iter;
+        
+        CHECK_EQUAL(
+            ( show::headers_type{} ),
+            iter -> headers()
+        );
+        CHECK_EQUAL(
+            "foo bar",
+            ( std::string{
+                std::istreambuf_iterator< char >( &*iter ),
+                {}
+            } )
+        );
+        ++iter;
+        
+        CHECK_EQUAL(
+            ( show::headers_type{} ),
+            iter -> headers()
+        );
+        CHECK_EQUAL(
+            "hello world",
+            ( std::string{
+                std::istreambuf_iterator< char >( &*iter ),
+                {}
+            } )
+        );
+        ++iter;
+        
+        CHECK_EQUAL(
+            test_multipart.end(),
+            iter
+        );
+    }
+    
+    TEST( ParseRecursive )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Content-Disposition: form-data; name=\"some-text\"\r\n"
+                + "\r\n"
+                "foo bar\r\n"
+                "--" + boundaryA + "\r\n"
+                "Content-Type: multipart/form-data; boundary=" + boundaryB + "\r\n"
+                "\r\n"
+                // "\r\n"
+                "--" + boundaryB + "\r\n"
+                "Content-Disposition: form-data; name=\"some-text\"\r\n"
+                "\r\n"
+                "hello world\r\n"
+                "--" + boundaryB + "\r\n"
+                "Content-Type: multipart/form-data; boundary=" + boundaryC + "\r\n"
+                "\r\n"
+                // "\r\n"
+                "--" + boundaryC + "\r\n"
+                "Content-Disposition: form-data; name=\"some-text\"\r\n"
+                "\r\n"
+                "qwerty\r\n"
+                "--" + boundaryC + "--\r\n"
+                "--" + boundaryB + "--\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart_A{
+            content,
+            boundaryA
+        };
+        auto iter_A = test_multipart_A.begin();
+        CHECK_EQUAL(
+            ( show::headers_type{
+                { "Content-Disposition", {
+                    "form-data; name=\"some-text\""
+                } }
+            } ),
+            iter_A -> headers()
+        );
+        CHECK_EQUAL(
+            "foo bar",
+            ( std::string{
+                std::istreambuf_iterator< char >( &*iter_A ),
+                {}
+            } )
+        );
+        ++iter_A;
+        {
+            CHECK_EQUAL(
+                ( show::headers_type{
+                    { "Content-Type", {
+                        "multipart/form-data; boundary=" + boundaryB
+                    } }
+                } ),
+                iter_A -> headers()
+            );
+            
+            show::multipart test_multipart_B{
+                *iter_A,
+                boundaryB
+            };
+            auto iter_B = test_multipart_B.begin();
+            CHECK_EQUAL(
+                ( show::headers_type{
+                    { "Content-Disposition", {
+                        "form-data; name=\"some-text\""
+                    } }
+                } ),
+                iter_B -> headers()
+            );
+            CHECK_EQUAL(
+                "hello world",
+                ( std::string{
+                    std::istreambuf_iterator< char >( &*iter_B ),
+                    {}
+                } )
+            );
+            ++iter_B;
+            {
+                CHECK_EQUAL(
+                    ( show::headers_type{
+                        { "Content-Type", {
+                            "multipart/form-data; boundary=" + boundaryC
+                        } }
+                    } ),
+                    iter_B -> headers()
+                );
+                
+                show::multipart test_multipart_C{
+                    *iter_B,
+                    boundaryC
+                };
+                auto iter_C = test_multipart_C.begin();
+                CHECK_EQUAL(
+                    ( show::headers_type{
+                        { "Content-Disposition", {
+                            "form-data; name=\"some-text\""
+                        } }
+                    } ),
+                    iter_C -> headers()
+                );
+                CHECK_EQUAL(
+                    "qwerty",
+                    ( std::string{
+                        std::istreambuf_iterator< char >( &*iter_C ),
+                        {}
+                    } )
+                );
+                ++iter_C;
+                CHECK_EQUAL(
+                    test_multipart_C.end(),
+                    iter_C
+                );
+            }
+            ++iter_B;
+            CHECK_EQUAL(
+                test_multipart_B.end(),
+                iter_B
+            );
+        }
+        ++iter_A;
+        CHECK_EQUAL(
+            test_multipart_A.end(),
+            iter_A
+        );
+    }
+    
+    TEST( IncrementUnfinishedSegment )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Content-Disposition: form-data; name=\"some-text\"\r\n"
+                "\r\n"
+                + long_message + "\r\n"
+                "--" + boundaryA + "\r\n"
+                "Content-Disposition: form-data; name=\"more-text\"\r\n"
+                + "\r\n"
+                "hello world\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        auto iter = test_multipart.begin();
+        
+        ++iter;
+        
+        CHECK_EQUAL(
+            "hello world",
+            ( std::string{
+                std::istreambuf_iterator< char >( &*iter ),
+                {}
+            } )
+        );
+        ++iter;
+        
+        CHECK_EQUAL(
+            test_multipart.end(),
+            iter
+        );
+    }
+    
+    TEST( FailMissingStartingBoundarySequence )
+    {
+        std::stringbuf content{
+            (
+                "\r\n"
+                "\r\n"
+                "foo bar\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        try
+        {
+            show::multipart{ content, boundaryA };
+            CHECK( false );
+        }
+        catch( const show::multipart_parse_error& e )
+        {
+            CHECK_EQUAL(
+                "multipart data did not start with boundary sequence",
+                e.what()
+            );
+        }
+    }
+    
+    TEST( FailMissingEndingBoundarySequence )
+    // a.k.a. FailPrematureEndInSegment
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "\r\n"
+                "foo bar"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{ content, boundaryA };
+        auto iter = test_multipart.begin();
+        try
+        {
+            auto segment_content = std::string{
+                std::istreambuf_iterator< char >( &*iter ),
+                {}
+            };
+            CHECK( false );
+        }
+        catch( const show::multipart_parse_error& e )
+        {
+            CHECK_EQUAL(
+                "premature end of multipart data",
+                e.what()
+            );
+        }
+    }
+    
+    TEST( FailPrematureEndInHeader )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Content-Disposition: form-data; name=\"some-text\"\r\n"
+                "Content-Type: image/"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{ content, boundaryA };
+        try
+        {
+            test_multipart.begin();
+            CHECK( false );
+        }
+        catch( const show::multipart_parse_error& e )
+        {
+            CHECK_EQUAL(
+                "premature end of multipart data",
+                e.what()
+            );
+        }
+    }
+    
+    TEST( FailPrematureEndBetweenHeaders )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Content-Disposition: form-data; name=\"some-text\"\r\n"
+                "Content-Type: image/gif\r\n"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{ content, boundaryA };
+        try
+        {
+            test_multipart.begin();
+            CHECK( false );
+        }
+        catch( const show::multipart_parse_error& e )
+        {
+            CHECK_EQUAL(
+                "premature end of multipart data",
+                e.what()
+            );
+        }
+    }
+    
+    TEST( FailMultipleCR )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Content-Disposition: form-data; name=\"some-text\"\r\r"
+                "Content-Type: image/gif\r\n"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{ content, boundaryA };
+        try
+        {
+            test_multipart.begin();
+            CHECK( false );
+        }
+        catch( const show::multipart_parse_error& e )
+        {
+            CHECK_EQUAL(
+                "malformed HTTP line ending in multipart data",
+                e.what()
+            );
+        }
+    }
+    
+    TEST( FailInvalidHeaderName )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Bad Header: good value\r\n"
+                "\r\n"
+                "\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        try
+        {
+            auto iter = test_multipart.begin();
+            CHECK( false );
+        }
+        catch( const show::multipart_parse_error& e )
+        {
+            CHECK_EQUAL(
+                "malformed header in multipart data",
+                e.what()
+            );
+        }
+    }
+    
+    TEST( FailMissingHeaderValueMiddle )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Bad-Header:\r\n"
+                "Good-Header: good value\r\n"
+                "\r\n"
+                "\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        try
+        {
+            auto iter = test_multipart.begin();
+            CHECK( false );
+        }
+        catch( const show::multipart_parse_error& e )
+        {
+            CHECK_EQUAL(
+                "missing header value in multipart data",
+                e.what()
+            );
+        }
+    }
+    
+    TEST( FailMissingHeaderValueEnd )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Bad-Header:\r\n"
+                "\r\n"
+                "\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        try
+        {
+            auto iter = test_multipart.begin();
+            CHECK( false );
+        }
+        catch( const show::multipart_parse_error& e )
+        {
+            CHECK_EQUAL(
+                "missing header value in multipart data",
+                e.what()
+            );
+        }
+    }
+    
+    TEST( FailMissingHeaderValueWithPadding )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Bad-Header: \r\n"
+                "\r\n"
+                "\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        try
+        {
+            auto iter = test_multipart.begin();
+            CHECK( false );
+        }
+        catch( const show::multipart_parse_error& e )
+        {
+            CHECK_EQUAL(
+                "missing header value in multipart data",
+                e.what()
+            );
+        }
+    }
+    
+    TEST( FailMissingHeaderPadding )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "Bad-Header:value\r\n"
+                "\r\n"
+                "\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        try
+        {
+            auto iter = test_multipart.begin();
+            CHECK( false );
+        }
+        catch( const show::multipart_parse_error& e )
+        {
+            CHECK_EQUAL(
+                "malformed header in multipart data",
+                e.what()
+            );
+        }
+    }
+    
+    TEST( FailDoubleBegin )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "\r\n"
+                "\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        auto iter1 = test_multipart.begin();
+        
+        try
+        {
+            auto iter2 = test_multipart.begin();
+            CHECK( false );
+        }
+        catch( const std::logic_error& e )
+        {
+            CHECK_EQUAL(
+                "already iterating over show::multipart",
+                e.what()
+            );
+        }
+    }
+    
+    TEST( FailDereferenceEndIterator )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "\r\n"
+                "\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        auto end_iter = test_multipart.end();
+        
+        try
+        {
+            auto& segment = *end_iter;
+            CHECK( false );
+        }
+        catch( const std::logic_error& e )
+        {
+            CHECK_EQUAL(
+                "can't dereference show::multipart::iterator at end",
+                e.what()
+            );
+        }
+    }
+    
+    TEST( FailIncrementEndIterator )
+    {
+        std::stringbuf content{
+            (
+                "--" + boundaryA + "\r\n"
+                "\r\n"
+                "\r\n"
+                "--" + boundaryA + "--"
+            ),
+            std::ios::in
+        };
+        
+        show::multipart test_multipart{
+            content,
+            boundaryA
+        };
+        auto end_iter = test_multipart.end();
+        
+        try
+        {
+            ++end_iter;
+            CHECK( false );
+        }
+        catch( const std::logic_error& e )
+        {
+            CHECK_EQUAL(
+                "can't increment show::multipart::iterator at end",
+                e.what()
+            );
+        }
+    }
+    
+    TEST( FailEmptyStringBoundary )
+    {
+        std::stringbuf content{
+            (
+                "--\r\n"
+                "\r\n"
+                "\r\n"
+                "----"
+            ),
+            std::ios::in
+        };
+        
+        try
+        {
+            show::multipart test_multipart{
+                content,
+                ""
+            };
+            CHECK( false );
+        }
+        catch( const std::invalid_argument& e )
+        {
+            CHECK_EQUAL(
+                "empty string as multipart boundary",
+                e.what()
+            );
+        }
+    }
+}

--- a/tests/multipart_tests.cpp
+++ b/tests/multipart_tests.cpp
@@ -169,42 +169,6 @@ SUITE( ShowMultipartTests )
             iter -> headers()
         );
         
-        // // DEBUG:
-        // std::string message;
-        // while( true )
-        // {
-        //     auto got_i = iter -> sbumpc();
-        //     auto got_c = std::streambuf::traits_type::to_char_type( got_i );
-            
-        //     if( std::streambuf::traits_type::not_eof( got_i ) != got_i )
-        //     {
-        //         std::cout
-        //             << "TEST( NoHeadersWithData ): eof, message is \""
-        //             << __show::escape_seq( message )
-        //             << "\""
-        //             << std::endl
-        //             << std::endl
-        //         ;
-        //         break;
-        //     }
-            
-        //     message += got_c;
-            
-        //     std::cout
-        //         << "TEST( NoHeadersWithData ): got char '"
-        //         << __show::escape_seq( { got_c } )
-        //         << "', message is \""
-        //         << __show::escape_seq( message )
-        //         << "\""
-        //         << std::endl
-        //         << std::endl
-        //     ;
-        // }
-        // CHECK_EQUAL(
-        //     "hello world",
-        //     message
-        // );
-        
         CHECK_EQUAL(
             "hello world",
             ( std::string{
@@ -349,15 +313,6 @@ SUITE( ShowMultipartTests )
             iter -> headers()
         );
         auto got_c = iter -> sgetc();
-        
-        // DEBUG:
-        std::cout
-            << "TEST( PermissiveNewlinesInBoundary ): got_c = "
-            << got_c
-            << ", not_eof = "
-            << show::multipart::segment::traits_type::not_eof( got_c )
-            << std::endl
-        ;
         
         CHECK(
             show::multipart::segment::traits_type::not_eof( got_c ) != got_c
@@ -599,7 +554,6 @@ SUITE( ShowMultipartTests )
                 "--" + boundaryA + "\r\n"
                 "Content-Type: multipart/form-data; boundary=" + boundaryB + "\r\n"
                 "\r\n"
-                // "\r\n"
                 "--" + boundaryB + "\r\n"
                 "Content-Disposition: form-data; name=\"some-text\"\r\n"
                 "\r\n"
@@ -607,7 +561,6 @@ SUITE( ShowMultipartTests )
                 "--" + boundaryB + "\r\n"
                 "Content-Type: multipart/form-data; boundary=" + boundaryC + "\r\n"
                 "\r\n"
-                // "\r\n"
                 "--" + boundaryC + "\r\n"
                 "Content-Disposition: form-data; name=\"some-text\"\r\n"
                 "\r\n"

--- a/tests/multipart_tests.cpp
+++ b/tests/multipart_tests.cpp
@@ -958,32 +958,6 @@ SUITE( ShowMultipartTests )
         );
     }
     
-    TEST( FailMissingStartingBoundarySequence )
-    {
-        std::stringbuf content{
-            (
-                "\r\n"
-                "\r\n"
-                "foo bar\r\n"
-                "--" + boundaryA + "--"
-            ),
-            std::ios::in
-        };
-        
-        try
-        {
-            show::multipart{ content, boundaryA };
-            CHECK( false );
-        }
-        catch( const show::multipart_parse_error& e )
-        {
-            CHECK_EQUAL(
-                "multipart data did not start with boundary sequence",
-                e.what()
-            );
-        }
-    }
-    
     TEST( FailMissingEndingBoundarySequence )
     // a.k.a. FailPrematureEndInSegment
     {


### PR DESCRIPTION
**TODO:**
- [x] Example program
- [x] Documentation
- [x] Fix failure to ignore content before first boundary
- [x] Clean up example program to use `std::stringstream` for analysis message (also maybe better analysis than just listing headers?)